### PR TITLE
Fix GitMe URL to correctly point to Github

### DIFF
--- a/2015-projects.md
+++ b/2015-projects.md
@@ -3,7 +3,7 @@ layout: default
 title: 2015 Projects
 ---
 
-### [GitMe](github.com/vivisthebest/GitMe) (Won Best Visual/UX Design!)
+### [GitMe](https://github.com/vivisthebest/GitMe) (Won Best Visual/UX Design!)
 #### Made by Viviana Yee, Kyle Holzinger, and Ivan Uvarov
 
 A tool for analyzing your GitHub commits.


### PR DESCRIPTION
The link was 404'ing to HackBeanpot's website, this change correctly points the URL to GitHub.
