### PR TITLE
2016 Project Listings!

### DIFF
--- a/2016-projects.md
+++ b/2016-projects.md
@@ -1,0 +1,140 @@
+---
+layout: default
+title: 2016 Projects
+---
+
+### [Ragtag](https://github.com/djkazic/ragtag) (Won Most Technically Challenging Award!) ###
+
+#### Made by Brittany Chiang, Kevin Cai, Teddy Burns ####
+
+### [PoliTweet](https://github.com/mgramigna/presidential-live-tweets) (Won Best Visual/UI/UX Design!) ###
+
+#### Made by Justin Kennedy, Andrew Bass, Mathew Gramigna, Jack Nichols ####
+
+### [Foam](https://github.com/LivD1125/HackBeanpot-Team-Foam.git) (Won Team Frosh Memorial Award!)###
+
+#### Made by Dylan Boudro, Erika McVey, Abhijeet Sharma, Olivia DeFlumeri, Nadine Shaalan, Bahar Haji-Sheikhi  ####
+
+### [khaled-script](https://www.npmjs.com/package/khaled-script) (Won Least Likely to Make Money Award!) ###
+
+#### Made by Arjun Balaji ####
+
+### [Pecan](https://github.com/OmkarB/pecan) (Won Best Use of Wolfram Technology Award!)###
+
+#### Made by Omkar Bhat, Ty Coghlan, Raj Narayan, Kevin Liu ####
+
+### [The Hound](https://github.com/coreycle/The-Hound) (Won indico's Prize!)###
+
+#### Made by Corey Clemente, Ebrahim Ebrahim, Dillon Sienko ####
+
+### [Happy](N/A) ###
+
+#### Made by Rebecca Bagley, Karen Zheung, Zhihe Shen, Tammy Huynh, Bjorn Shen ####
+
+### [What's On My Plate (WOMP)/Team Cool Kids](http://xiifulminata.github.io/WhatsOnMyPlate/) ###
+
+#### Made by Gary Calzada, Victoria Yang, Yifan Xing, Jovaun Jackson, Monsurat Olaosebikan ####
+
+### [Hack Connection](https://github.com/nathansomething/hack-connection) ###
+
+#### Made by Nathan Goodman, Angela Massey, Charlotte O'Neill, Logan Moore, Emily Hontoria ####
+
+### [Sharks and Minnows ](https://github.com/dqgorelick/digital-ocean) ###
+
+#### Made by Chris DeLucia, Dan Gorelick, Huy Le, Cheyan Setayesh, Andy Shen, Kaitlen Sousa, Simon Ton ####
+
+### [metric-me](hacks.ramimac.me) ###
+
+#### Made by Rami McCarthy, Tom Kowalski & David Shoyket ####
+
+### [GamePackCast](https://github.com/alfred/hackbeanpot16) ###
+
+#### Made by Alfred Ababio, Matthew Capone, Brendan Ross, Joseph Crotty, ####
+
+### [Long Story Short](https://github.com/bdatdo0601/StoryTelling) ###
+
+#### Made by Dat Bac Do, Kyle Frick, An Huynh, Justin Wright ####
+
+### [AfroCoding](https://github.com/agrundw/HackBeanpot2016) ###
+
+#### Made by Alex Grundwerg, Dorian Franklin ####
+
+### [Emovi (by the Gettem Next Timers)](https://github.com/westinn/Emovi) ###
+
+#### Made by Daniel Cohen and Nicolas Westin ####
+
+### [Matthias Madness](https://github.com/emilydaniel/Matthias-Madness.git) ###
+
+#### Made by Emily Daniel ####
+
+### [Snappage](locally hosted as of now) ###
+
+#### Made by Patrick Watrous ####
+
+### [alejoseb](https://github.com/alejoseb/) ###
+
+#### Made by Alejandro Mera ####
+
+### [Close Call](https://github.com/golf1052/close-call    http://hotlinering.com/) ###
+
+#### Made by Nat Dempkowski, Andrew Knueven, Sanders Lauture, Tevin Otieno ####
+
+### [Ambeyonce](https://github.com/TheMichaelHu/Ambeyonce) ###
+
+#### Made by Michael Hu, Nikolai Wotton, Quan Do, Kevin Luo ####
+
+### [Startup Query Language](N/A) ###
+
+#### Made by Michael Coppola ####
+
+### [Team Giant Robot Dog](https://github.com/johncomposed/scheduleThis/) ###
+
+#### Made by Matthew Coleman, John Williams, Max Lever ####
+
+### [binfmt_mysc](https://github.com/mossberg/binfmt_mysc) ###
+
+#### Made by Mark Mossberg ####
+
+### [A Hard G](https://github.com/genagain/vacant-feeds) ###
+
+#### Made by Gen Ohta ####
+
+### [My Immortal Hotline](https://github.com/superjabenman/My-Immortal-Hotline) ###
+
+#### Made by Jaben McCormack ####
+
+### [MealMate/Fanatic Four](https://github.com/Fanatic-Four/Meal-Mate) ###
+
+#### Made by Tommy Nguyen, Calvin Mei, Kayla Nguyen, Michelle Chan ####
+
+### [Gungho](https://github.com/Kibii/Gungho) ###
+
+#### Made by Catherine Feldman, Adam Mullarkey, James Yanyuk, and Michael Markman ####
+
+### [Sassmates](https://github.com/nioushajafari/hackbeanpot-2016) ###
+
+#### Made by Adrian Kant, Niousha Jafari, Jaclyn Iulianetti ####
+
+### [Cai](iPhone App) ###
+
+#### Made by Vignesh Mohankumar, Eric Yu ####
+
+### [AWSomeButton](https://github.com/stokesbga/AWSomeButton) ###
+
+#### Made by Alexey Shablygin, Alexander Stokes ####
+
+### [statly](https://github.com/cwheel/statly) ###
+
+#### Made by James Sullivan, Cameron Wheeler ####
+
+### [Addi](https://github.com/nickzuber/addi) ###
+
+#### Made by Danielle Nguyen, Nick Zuber ####
+
+### [Relationship Tracker](https://github.com/marshallewhite/RelationshipTracker) ###
+
+#### Made by Marshall White ####
+
+### [NoSleepNoseBleed](https://github.com/l-tn3314/UFree) ###
+
+#### Made by Tina Lee, Gabriel Centeno, Kristy Chen, Trent Duffy ####

--- a/_data/year.yml
+++ b/_data/year.yml
@@ -1,3 +1,6 @@
+- url: 2016-projects.html
+  title: 2016
+
 - url: 2015-projects.html
   title: 2015
 


### PR DESCRIPTION
As we did the past few years, we're publishing a list of awesome things made at HackBeanpot 2016! Whooo!

I'm planning on merging the `2016-content` branch into `markdown` (and subsequently live to `gh-pages`) by Friday, February 26, 2016.

It'd be wonderful if ya'll could add a few sentences on what your project does, what it's made with, etc etc. Or if you linked your name to your website/twitter/github. Or if you updated your project's URL, if need be. Or if you fixed any other errors.

Edits/corrections may be submitted via PR (use the `2016-content` branch as the base branch), or in the comments, or in an email to team@hackbeanpot.com.

Thanks! :smile: 
