### PR TITLE
Fix Close Call and UntitledMixtapes URLs

### DIFF
--- a/2014-projects.md
+++ b/2014-projects.md
@@ -88,7 +88,7 @@ laptops. We exploit the abundant users of data connecting websites like Google,
 Wikipedia, and YouTube, and provide a Chrome extension that eases and speeds the
 processing of information on the web.
 
-### [Untitled Mixtapes](http://www.untitledmixtap.es) (Won Best Use of APIs!)###
+### [Untitled Mixtapes](https://github.com/natdempk/untitledmixtapes) (Won Best Use of APIs!)###
 
 #### Made by Zack Hickman, Nat Dempkowski, and Sanders Lauture ####
 

--- a/2016-projects.md
+++ b/2016-projects.md
@@ -75,7 +75,7 @@ title: 2016 Projects
 
 #### Made by Alejandro Mera ####
 
-### [Close Call](https://github.com/golf1052/close-call    http://hotlinering.com/) ###
+### [Close Call](https://github.com/golf1052/close-call) ###
 
 #### Made by Nat Dempkowski, Andrew Knueven, Sanders Lauture, Tevin Otieno ####
 


### PR DESCRIPTION
The Close Call URL was malformed, and the UntitledMixtapes site no longer exists online, so point them both to their respective GitHub repos.

💻 🌐 🖱 